### PR TITLE
fix import for children example

### DIFF
--- a/docs-src/withChildren.tsx
+++ b/docs-src/withChildren.tsx
@@ -28,7 +28,7 @@ export const WithChildrenExample: React.FunctionComponent = () => {
         <MyApp />
       </div>
       <SyntaxHighlighter language="tsx" style={syntaxStyle}>
-        {`  import CircularSliderWithChildren from 'react-circular-slider-svg';
+        {`  import { CircularSliderWithChildren } from 'react-circular-slider-svg';
 
   const MyApp: React.FunctionComponent = () => {
     const [value1, setValue1] = useState(20);


### PR DESCRIPTION
the existing example is misleading, the default export is without children:

![image](https://github.com/mnkhouri/react-circular-slider/assets/13419087/0f9352cd-7dc7-4437-813e-07b4e92e0045)

anyway, awesome work!